### PR TITLE
[readme][s]: Add relevant info from frictionlessdata/forum - refs #525

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,23 @@
 # Frictionless - Project Management
 
-This is a repo for managing the Frictionless project  https://frictionlessdata.io/
+This is a repo for managing the Frictionless project – https://frictionlessdata.io/
 
-As such it is more core team focused :smile:
+As such it is more core team focused. :smile:
 
 * Frictionless Data: https://frictionlessdata.io/
 * Specifications: https://specs.frictionlessdata.io/
-* Forum: https://github.com/frictionlessdata/forum
+* Discussion forums: https://github.com/frictionlessdata/project/discussions
 * Chat: Discord https://discord.gg/2UgfM2k
 * Code of Conduct: https://frictionlessdata.io/code-of-conduct/
 
 ## Where to open issues?
 
-Summary:
+**Summary**:
 
-* Forum: https://github.com/frictionlessdata/forum/issues the default place for anyone out there to open an issue. It means *one* place for people to do that. Forum is a welcoming place where people can open a first issue, have a look around etc. If those issues are substantive they may move elsewhere ... (e.g. i did that with a spec issue recently). But it's a good landing spot.
-  * Also the catch-all for general questions, suggestions, ideas, support requests etc.
-* Project: https://github.com/frictionlessdata/project/issues the default place for core team to organize and plan work, schedule sprints etc. NOT for general discussion, ideas, support etc.
-* Specs: https://github.com/frictionlessdata/specs/issues
-
+* **Discussions**: https://github.com/frictionlessdata/project/discussions – the default place for anyone out there to open an issue. It means *one* place for people to do that. Discussions is a welcoming place where people can open a first issue, have a look around, etc. If those issues are substantive, they may move elsewhere (e.g. I did that with a spec issue recently)... But it's a good landing spot.
+  * Also the catch-all for general questions, suggestions, ideas, support requests, etc.
+* **Project**: https://github.com/frictionlessdata/project/issues – the default place for core team to organize and plan work, schedule sprints, etc. **NOT** for general discussion, ideas, support, etc.
+* **Specs**: https://github.com/frictionlessdata/specs/issues
 
 ## Libraries Status
 


### PR DESCRIPTION
* Add info from [frictionlessdata/forum/README.md](https://github.com/frictionlessdata/forum/blob/master/README.md): the repo is going to be deprecated.
* Update references to issues/forum repo to use "Discussions" instead, a new GitHub feature. https://github.com/frictionlessdata/project/discussions

Task item from #525.

---

Please preserve this line to notify @lwinfree (lead of this repository)
